### PR TITLE
Fixing CORS issue for environment variable

### DIFF
--- a/environments/environment.prod.ts
+++ b/environments/environment.prod.ts
@@ -7,7 +7,7 @@ export const environment ={
     apiUrl: 'https://datieskca7hlzshr3hgso4vacu0yfscv.lambda-url.us-east-1.on.aws/',
 
     // processEmailPhp: 'processEmail.php',
-    processEmailPhp: 'https://debookmagickey.com/processEmail.php',
+    processEmailPhp: '/processEmail.php',
     
     
 }


### PR DESCRIPTION
The website can load as www.debookmagickey.com or debookmagickey.com so we need to make the environment paths relative so they work no matter what. 